### PR TITLE
Deploy continuously

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,30 @@
+name: GitHub pages
+
+on:
+  push:
+    branches:
+      - deploy  # Set a branch that will trigger a deployment
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.107.0'
+
+      - name: Build Hugo
+        run: hugo --minify
+
+      - name: Deploy ./public directory to the remote gh-pages branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: GitHub pages
+name: Deploy to GitHub Pages
 
 on:
   push:
@@ -15,12 +15,12 @@ jobs:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
-      - name: Setup Hugo
+      - name: Set Hugo up
         uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: '0.107.0'
 
-      - name: Build Hugo
+      - name: Build with Hugo
         run: hugo --minify
 
       - name: Deploy ./public directory to the remote gh-pages branch

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ public/.DS_Store
 public
 /.project
 .hugo_build.lock
+resources/_gen/
 
 # VSCode
 .vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "themes/ananke"]
+	path = themes/ananke
+	url = https://github.com/theNewDynamic/gohugo-theme-ananke

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,6 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+draft: true
+---
+

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,4 @@
+baseURL = 'https://docs.opentermsarchive.org/'
+languageCode = 'en-us'
+title = 'Open Terms Archive documentation'
+theme = 'ananke'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "open-terms-archive-doc",
+  "name": "open-terms-archive-docs",
   "version": "0.0.1",
   "description": "The Open Terms Archive documentation.",
   "homepage": "https://github.com/OpenTermsArchive/doc#readme",


### PR DESCRIPTION
Deploy continuously with GitHub actions:
- Setup and build Hugo with `peaceiris/actions-hugo@v2`
- Deploy ./public directory to the remote gh-pages branch with `peaceiris/actions-gh-pages@v3`

Configure repository build and deployment:
![image](https://user-images.githubusercontent.com/364319/204333157-18f5ceee-bf14-4332-88ab-c5505b09fac7.png)

Initialize a basic theme to have content to deploy:
[https://opentermsarchive.github.io/doc/](https://opentermsarchive.github.io/doc/)

To test I used this branch `deploy` to trigger a deployment. This value must be modified for the`main` branch after review validation.
