### PR TITLE
Run deploy action when engine release

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,6 +1,8 @@
 name: Deploy to GitHub Pages
 
 on:
+  repository_dispatch:
+    types: [ "engine-release" ]
   push:
     branches: [ main ]
 
@@ -12,6 +14,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+
+      - name: "On engine release"
+        if: github.event.action == 'engine-release'
+        run: echo "Open Terms Archive engine release, version ${{ github.event.client_payload.version }}"
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
When `engine-release` event is received, build and deploy the documentation website to the JSDoc.