### PR TITLE
Add tracking code

### DIFF
--- a/themes/opentermsarchive/layouts/partials/footer.html
+++ b/themes/opentermsarchive/layouts/partials/footer.html
@@ -77,3 +77,20 @@
 
 {{ $headerJs := resources.Get "js/header.js" | js.Build }}
 <script src="{{ $headerJs.RelPermalink }}"></script>
+
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setExcludedQueryParams", ["simulationId","_csrf"]]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://stats.data.gouv.fr/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '179']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->

--- a/themes/opentermsarchive/layouts/partials/head.html
+++ b/themes/opentermsarchive/layouts/partials/head.html
@@ -17,4 +17,20 @@
 	<link rel="mask-icon" href="/favicon/safari-pinned-tab.svg" color="#000" />
 	<meta name="msapplication-TileColor" content="#ffffff" />
 	<meta name="theme-color" content="#ffffff" />
+	<!-- Matomo -->
+	<script>
+		var _paq = window._paq = window._paq || [];
+		/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+		_paq.push(["setExcludedQueryParams", ["simulationId","_csrf"]]);
+		_paq.push(['trackPageView']);
+		_paq.push(['enableLinkTracking']);
+		(function() {
+			var u="https://stats.data.gouv.fr/";
+			_paq.push(['setTrackerUrl', u+'matomo.php']);
+			_paq.push(['setSiteId', '179']);
+			var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+			g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+		})();
+	</script>
+	<!-- End Matomo Code -->
 </head>

--- a/themes/opentermsarchive/layouts/partials/head.html
+++ b/themes/opentermsarchive/layouts/partials/head.html
@@ -17,20 +17,4 @@
 	<link rel="mask-icon" href="/favicon/safari-pinned-tab.svg" color="#000" />
 	<meta name="msapplication-TileColor" content="#ffffff" />
 	<meta name="theme-color" content="#ffffff" />
-	<!-- Matomo -->
-	<script>
-		var _paq = window._paq = window._paq || [];
-		/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-		_paq.push(["setExcludedQueryParams", ["simulationId","_csrf"]]);
-		_paq.push(['trackPageView']);
-		_paq.push(['enableLinkTracking']);
-		(function() {
-			var u="https://stats.data.gouv.fr/";
-			_paq.push(['setTrackerUrl', u+'matomo.php']);
-			_paq.push(['setSiteId', '179']);
-			var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-			g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-		})();
-	</script>
-	<!-- End Matomo Code -->
 </head>


### PR DESCRIPTION
Add Matomo tracking code to documentation website to better measure the use of the documentation.