### PR TITLE
docs: Documentation was misspelled

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -60,7 +60,7 @@ pluralizelisttitles = false
 				weight = 3
 
 			[[languages.en.menu.footer]]
-				name = "Documenation"
+				name = "Documentation"
 				url = "https://docs.opentermsarchive.org"
 				weight = 4
 

--- a/config/_default/menus.en.yaml
+++ b/config/_default/menus.en.yaml
@@ -21,7 +21,7 @@ footer:
   - name: About
     url: https://opentermsarchive.org/about
     weight: 3
-  - name: Documenation
+  - name: Documentation
     url: https://docs.opentermsarchive.org
     weight: 4
 first_subfooter:


### PR DESCRIPTION
#### What does this PR do?

Fixes https://github.com/OpenTermsArchive/docs/issues/37

#### Description of Task to be completed?

Change **Documenation** to **Documentation** in relevant files.

#### How should this be manually tested?

git checkout to this branch, locally build, and then run the site. The error is fixed.

#### Screenshots (if appropriate)

Before:

<img width="418" alt="Screenshot 2023-03-14 at 21 31 57" src="https://user-images.githubusercontent.com/15629602/225290250-7203506d-8c8e-4705-8351-f0922d078dbc.png">

After:

<img width="421" alt="Screenshot 2023-03-14 at 22 03 13" src="https://user-images.githubusercontent.com/15629602/225290298-5c5dbabb-38f6-4960-8098-4153859e19cc.png">
