### PR TITLE
Changed ID to Service ID 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ To build it, [install Hugo](https://gohugo.io/getting-started/installing/) and [
 
 ```sh
 git clone https://github.com/OpenTermsArchive/docs
-cd docs
 hugo
 npm install
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To build it, [install Hugo](https://gohugo.io/getting-started/installing/) and [
 
 ```sh
 git clone https://github.com/OpenTermsArchive/docs
+cd docs
 hugo
 npm install
 ```

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -485,6 +485,7 @@ First of all, follow the [requirements](#requirements) above. Then, clone the re
 
 ```sh
 git clone https://github.com/OpenTermsArchive/engine.git
+cd engine
 ```
 
 Install dependencies:

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -485,7 +485,6 @@ First of all, follow the [requirements](#requirements) above. Then, clone the re
 
 ```sh
 git clone https://github.com/OpenTermsArchive/engine.git
-cd OpenTermsArchive
 ```
 
 Install dependencies:

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -143,7 +143,7 @@ In an editor, create the following declaration file in `declarations/Open Terms 
 In the terminal:
 
 ```sh
-npx ota-track
+npx ota track
 ```
 
 The tracked terms can be found in the `data` folder.

--- a/content/contributing-terms.en.md
+++ b/content/contributing-terms.en.md
@@ -12,7 +12,7 @@ Before adding new terms, open the [`declarations`](./declarations) folder and ch
 
 ### Declaring a new service
 
-Before declaring a service, you will need to choose its name and ID. The service ID will be the name of the JSON file in which the service will be declared. It is a normalised version of the service name.
+Before declaring a service, you will need to choose the service name and service ID. The service ID will be the name of the JSON file in which the service will be declared. It is a normalised version of the service name.
 
 ### Service name
 

--- a/content/contributing-terms.en.md
+++ b/content/contributing-terms.en.md
@@ -12,7 +12,7 @@ Before adding new terms, open the [`declarations`](./declarations) folder and ch
 
 ### Declaring a new service
 
-Before declaring a service, you will need to choose its name and ID. The ID will be the name of the JSON file in which the service will be declared. It is a normalised version of the service name.
+Before declaring a service, you will need to choose its name and ID. The service ID will be the name of the JSON file in which the service will be declared. It is a normalised version of the service name.
 
 ### Service name
 


### PR DESCRIPTION
### Fixes
THis pull request resolves #51, #50, #49 and #52

### Details
- [Issue fix 19](https://github.com/OpenTermsArchive/docs/issues/52) - I changed ID to Service ID in the Contributing terms documentation to ensure more clarity and consistency with the naming
- [Issue fix 9](https://github.com/OpenTermsArchive/docs/issues/49) - I changed the npx command to `npx ota track`
- [Issue fix 21](https://github.com/OpenTermsArchive/docs/issues/50) - I removed the command `cd docs` from the ReadMe file as there was no directory called docs and it seemed obsolete 
- [Issue fix 11](https://github.com/OpenTermsArchive/docs/issues/51) - I removed the command `cd OpenTermsArchive` from the docs as there was no directory like that and it seemed obsolete 