### PR TITLE
Fix broken link 1 in contributing terms

### DIFF
--- a/content/contributing-terms.en.md
+++ b/content/contributing-terms.en.md
@@ -54,7 +54,7 @@ The service ID is exposed to developers. It should be easy to handle with script
   - _Example: `App Store` → `App Store`_.
   - _Example: `DeviantArt` → `DeviantArt`_.
 
-> If you have a hard time defining the service ID, check out the [practical guidelines to derive the ID from the service name](declarations-guidelines.md#service-id), and feel free to mention your uncertainties in the pull request! We will help you improve the service ID if necessary 🙂
+> If you have a hard time defining the service ID, check out the [practical guidelines to derive the ID from the service name](./guidelines/declaring.en.md#service-id), and feel free to mention your uncertainties in the pull request! We will help you improve the service ID if necessary 🙂
 
 > More details on the ID and naming constraints and recommendations can be found in the relevant [decision record](https://github.com/OpenTermsArchive/engine/blob/main/decision-records/0001-service-name-and-id.md).
 


### PR DESCRIPTION
##Fixes
This fixes #53  

I fixed a broken link to point to info on Service ID in the guidelines docs