### PR TITLE
Fix broken links in Contributing Terms page

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -75,6 +75,13 @@ A **declaration** also contains some metadata on the **service** on which the **
 
 - - -
 
+### How it works
+
+1. **Targeting**: The contractual documents of a service are targeted by volunteer contributors or partners.
+2. **Tracking**: Several times a day, our robots download and publicly archive the targeted documents.
+3. **Analysing**: When changes are spotted, they are recorded and exposed for human analysts.
+4. **Disseminating**: All recorded versions are published in datasets enabling reuse and research.
+
 ## Add terms to a collection
 
 Open Terms Archive **acquires** **terms** to deliver an explorable **history** of **changes**. This can be done in two ways:

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -75,13 +75,6 @@ A **declaration** also contains some metadata on the **service** on which the **
 
 - - -
 
-### How it works
-
-1. **Targeting**: The contractual documents of a service are targeted by volunteer contributors or partners.
-2. **Tracking**: Several times a day, our robots download and publicly archive the targeted documents.
-3. **Analysing**: When changes are spotted, they are recorded and exposed for human analysts.
-4. **Disseminating**: All recorded versions are published in datasets enabling reuse and research.
-
 ## Add terms to a collection
 
 Open Terms Archive **acquires** **terms** to deliver an explorable **history** of **changes**. This can be done in two ways:

--- a/content/contributing-terms.en.md
+++ b/content/contributing-terms.en.md
@@ -34,7 +34,7 @@ The service name is exposed to end users. It should reflect as closely as possib
   - _Example: `Firebase` (by Google) → `Firebase`_.
   - _Example: `App Store` (by Apple) → `App Store`_.
 
-> If you have a hard time finding the service name, check out the [practical guidelines to find the service name](./guidelines/declaring.en.md#service-name), and feel free to mention your uncertainties in the pull request! We will help you improve the service name if necessary 🙂
+> If you have a hard time finding the service name, check out the [practical guidelines to find the service name](../guidelines/declaring#service-name), and feel free to mention your uncertainties in the pull request! We will help you improve the service name if necessary 🙂
 
 ### Service ID
 
@@ -54,7 +54,7 @@ The service ID is exposed to developers. It should be easy to handle with script
   - _Example: `App Store` → `App Store`_.
   - _Example: `DeviantArt` → `DeviantArt`_.
 
-> If you have a hard time defining the service ID, check out the [practical guidelines to derive the ID from the service name](./guidelines/declaring.en.md#service-id), and feel free to mention your uncertainties in the pull request! We will help you improve the service ID if necessary 🙂
+> If you have a hard time defining the service ID, check out the [practical guidelines to derive the ID from the service name](../guidelines/declaring#service-id), and feel free to mention your uncertainties in the pull request! We will help you improve the service ID if necessary 🙂
 
 > More details on the ID and naming constraints and recommendations can be found in the relevant [decision record](https://github.com/OpenTermsArchive/engine/blob/main/decision-records/0001-service-name-and-id.md).
 

--- a/content/contributing-terms.en.md
+++ b/content/contributing-terms.en.md
@@ -6,9 +6,9 @@ title: "Contributing terms"
 
 ## Tracking new terms
 
-Tracking terms is done by _declaring_ them and the service they are associated with. Such a declaration is achieved by editing JSON files in the [`declarations`](./declarations) folder.
+Tracking terms is done by _declaring_ them and the service they are associated with. Such a declaration is achieved by editing JSON files in the [`declarations`](https://github.com/OpenTermsArchive/contrib-declarations/tree/main/declarations) folder.
 
-Before adding new terms, open the [`declarations`](./declarations) folder and check if the service you want to track terms for is already declared. If a JSON file with the name of the service is already present, you can jump straight to [declaring terms](#declaring-terms). Otherwise, keep reading!
+Before adding new terms, open the [`declarations`]([./declarations](https://github.com/OpenTermsArchive/contrib-declarations/tree/main/declarations)) folder and check if the service you want to track terms for is already declared. If a JSON file with the name of the service is already present, you can jump straight to [declaring terms](#declaring-terms). Otherwise, keep reading!
 
 ### Declaring a new service
 

--- a/content/contributing-terms.en.md
+++ b/content/contributing-terms.en.md
@@ -102,7 +102,7 @@ Let’s start by defining these keys!
 
 This property should simply contain the URL at which the terms you want to track can be downloaded. HTML and PDF files are supported.
 
-When terms coexist in different languages and jurisdictions, please refer to the [scope of the collection](../README.md#collections) to which you are contributing. This scope is usually defined in the README.
+When terms coexist in different languages and jurisdictions, please refer to the [scope of the collection](../#collections) to which you are contributing. This scope is usually defined in the README.
 
 #### `select`
 

--- a/content/contributing-terms.en.md
+++ b/content/contributing-terms.en.md
@@ -34,7 +34,7 @@ The service name is exposed to end users. It should reflect as closely as possib
   - _Example: `Firebase` (by Google) → `Firebase`_.
   - _Example: `App Store` (by Apple) → `App Store`_.
 
-> If you have a hard time finding the service name, check out the [practical guidelines to find the service name](declarations-guidelines.md#service-name), and feel free to mention your uncertainties in the pull request! We will help you improve the service name if necessary 🙂
+> If you have a hard time finding the service name, check out the [practical guidelines to find the service name](./guidelines/declaring.en.md#service-name), and feel free to mention your uncertainties in the pull request! We will help you improve the service name if necessary 🙂
 
 ### Service ID
 
@@ -54,7 +54,7 @@ The service ID is exposed to developers. It should be easy to handle with script
   - _Example: `App Store` → `App Store`_.
   - _Example: `DeviantArt` → `DeviantArt`_.
 
-> If you have a hard time defining the service ID, check out the [practical guidelines to derive the ID from the service name](declarations-guidelines.md#service-id), and feel free to mention your uncertainties in the pull request! We will help you improve the service ID if necessary 🙂
+> If you have a hard time defining the service ID, check out the [practical guidelines to derive the ID from the service name](./guidelines/declaring.en.md#service-id), and feel free to mention your uncertainties in the pull request! We will help you improve the service ID if necessary 🙂
 
 > More details on the ID and naming constraints and recommendations can be found in the relevant [decision record](https://github.com/OpenTermsArchive/engine/blob/main/decision-records/0001-service-name-and-id.md).
 

--- a/content/contributing-terms.en.md
+++ b/content/contributing-terms.en.md
@@ -108,7 +108,7 @@ When terms coexist in different languages and jurisdictions, please refer to the
 
 _This property is not needed for PDF documents._
 
-Most of the time, contractual documents are exposed as web pages, with a header, a footer, navigation menus, possibly ads… We aim at tracking only the significant parts of the document. In order to achieve that, the `select` property allows to extract only those parts in the process of [converting from snapshot to version](../#how-it-works).
+Most of the time, contractual documents are exposed as web pages, with a header, a footer, navigation menus, possibly ads… We aim at tracking only the significant parts of the document. In order to achieve that, the `select` property allows to extract only those parts in the process of [converting from snapshot to version](https://opentermsarchive.org/#how-it-works).
 
 The `select` value can be either a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors), a [range selector](#range-selectors) or an array of those.
 

--- a/content/contributing-terms.en.md
+++ b/content/contributing-terms.en.md
@@ -108,7 +108,7 @@ When terms coexist in different languages and jurisdictions, please refer to the
 
 _This property is not needed for PDF documents._
 
-Most of the time, contractual documents are exposed as web pages, with a header, a footer, navigation menus, possibly ads… We aim at tracking only the significant parts of the document. In order to achieve that, the `select` property allows to extract only those parts in the process of [converting from snapshot to version](../README.md#how-it-works).
+Most of the time, contractual documents are exposed as web pages, with a header, a footer, navigation menus, possibly ads… We aim at tracking only the significant parts of the document. In order to achieve that, the `select` property allows to extract only those parts in the process of [converting from snapshot to version](../#how-it-works).
 
 The `select` value can be either a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors), a [range selector](#range-selectors) or an array of those.
 


### PR DESCRIPTION
## Fixes
This fixes partially #53 

I modified link targeting service name in guidelines docs