### PR TITLE
Add the troubleshooting and communication section

### DIFF
--- a/content/guidelines/declaring.en.md
+++ b/content/guidelines/declaring.en.md
@@ -194,13 +194,13 @@ You can only use our copyrights or [trademarks (or any similar marks)](https://l
 Write a filter in the declaration.
 
 - - -
-## Troubleshooting and Communication
 
-While using the graphical user interface for contribution, you may come across a broken page or error while fetching terms due to the engine's limitations, we encourage you to refresh the page or contact the team by tapping the “Let us know” button.
+## Blank page when contacting support
 
-<img width="586" alt="Screen Shot 2023-08-24 at 18 06 08" src="https://github.com/OpenTermsArchive/docs/assets/41474439/6b31580a-8a2a-47cc-88a4-8b02a19cf181">
+While using the graphical user interface for contribution, you may come across a blank page when trying to contact the team.
 
-In some cases, clicking on this button may lead you to a blank page, which is often caused by your default mailto handler not being set to Gmail. 
-We recommend following [these instructions](https://support.google.com/chrome/thread/57026170/how-to-add-gmail-as-default-mailto-handler?hl=en) to add Gmail as your default mailto handler and trying again.
+This may be caused by the lack of a mail program being set up in your browser.
 
+#### Solution
 
+If you use Gmail, for example, [these instructions](https://support.google.com/chrome/thread/57026170/how-to-add-gmail-as-default-mailto-handler) explain how to add Gmail as the default `mailto` handler in Chrome. Try following them and trying again.

--- a/content/guidelines/declaring.en.md
+++ b/content/guidelines/declaring.en.md
@@ -194,6 +194,7 @@ You can only use our copyrights or [trademarks (or any similar marks)](https://l
 Write a filter in the declaration.
 
 ### Troubleshooting and Communication
+
 If you encounter issues due to the engine's limitations in reading website URL, such as the fetchDocument error, don't worry, either refresh the page or click on the "Let us know" button, in order to get in touch with the team.
 
 There's a possibility that this button leads you to a blank page. This is often caused by your default mailto handler not being set to gmail. We recommend following [these instructions](https://support.google.com/chrome/thread/57026170/how-to-add-gmail-as-default-mailto-handler?hl=en) and trying again.

--- a/content/guidelines/declaring.en.md
+++ b/content/guidelines/declaring.en.md
@@ -192,3 +192,10 @@ You can only use our copyrights or [trademarks (or any similar marks)](https://l
 #### Solution
 
 Write a filter in the declaration.
+
+### Troubleshooting and Communication
+If you encounter issues due to the engine's limitations in reading website URL, such as the fetchDocument error, don't worry, either refresh the page or click on the "Let us know" button, in order to get in touch with the team.
+
+There's a possibility that this button leads you to a blank page. This is often caused by your default mailto handler not being set to gmail. We recommend following [these instructions](https://support.google.com/chrome/thread/57026170/how-to-add-gmail-as-default-mailto-handler?hl=en) and trying again.
+
+Thank you for your contribution!

--- a/content/guidelines/declaring.en.md
+++ b/content/guidelines/declaring.en.md
@@ -193,10 +193,14 @@ You can only use our copyrights or [trademarks (or any similar marks)](https://l
 
 Write a filter in the declaration.
 
-### Troubleshooting and Communication
+- - -
+## Troubleshooting and Communication
 
-If you encounter issues due to the engine's limitations in reading website URL, such as the fetchDocument error, don't worry, either refresh the page or click on the "Let us know" button, in order to get in touch with the team.
+While using the graphical user interface for contribution, you may come across a broken page or error while fetching terms due to the engine's limitations, we encourage you to refresh the page or contact the team by tapping the “Let us know” button.
 
-There's a possibility that this button leads you to a blank page. This is often caused by your default mailto handler not being set to gmail. We recommend following [these instructions](https://support.google.com/chrome/thread/57026170/how-to-add-gmail-as-default-mailto-handler?hl=en) and trying again.
+<img width="586" alt="Screen Shot 2023-08-24 at 18 06 08" src="https://github.com/OpenTermsArchive/docs/assets/41474439/6b31580a-8a2a-47cc-88a4-8b02a19cf181">
 
-Thank you for your contribution!
+In some cases, clicking on this button may lead you to a blank page, which is often caused by your default mailto handler not being set to Gmail. 
+We recommend following [these instructions](https://support.google.com/chrome/thread/57026170/how-to-add-gmail-as-default-mailto-handler?hl=en) to add Gmail as your default mailto handler and trying again.
+
+

--- a/content/guidelines/declaring.en.md
+++ b/content/guidelines/declaring.en.md
@@ -195,7 +195,9 @@ Write a filter in the declaration.
 
 - - -
 
-## Blank page when contacting support
+## Using the graphical contribution interface
+
+### Blank page when contacting support
 
 While using the graphical user interface for contribution, you may come across a blank page when trying to contact the team.
 


### PR DESCRIPTION
Document how to circumvent the blank screen problem following a mailto link.

Follows https://github.com/OpenTermsArchive/contribution-tool/issues/151.