### PR TITLE
Use relative URL to the ressource

### DIFF
--- a/themes/opentermsarchive/layouts/partials/aside.html
+++ b/themes/opentermsarchive/layouts/partials/aside.html
@@ -7,7 +7,7 @@
 				{{ if eq .Kind slice "section" "page" "home" }}
 					{{ if eq .Type "page" }}
 						<li class="aside_item {{ if eq $currentPageTitle .Title }}aside_item-current{{ end }}">
-							<a href="{{ .Permalink }}">{{ .Title }}</a>
+							<a href="{{ .RelPermalink }}">{{ .Title }}</a>
 							{{ if eq $currentPageTitle .Title }}
 								{{ .Page.TableOfContents }}
 							{{ end }}
@@ -18,7 +18,7 @@
 							<ul class="aside_subitems">
 								{{ range where .Pages "Section" .Section }}
 									<li class="aside_subitem">
-										<a href="{{ .Permalink }}">{{ .Title }}</a>
+										<a href="{{ .RelPermalink }}">{{ .Title }}</a>
 										{{ if eq $currentPageTitle .Title }}
 											{{ .Page.TableOfContents }}
 										{{ end }}

--- a/themes/opentermsarchive/layouts/partials/head.html
+++ b/themes/opentermsarchive/layouts/partials/head.html
@@ -8,7 +8,7 @@
 		<link rel="stylesheet" href="{{ $styles.RelPermalink }}">
 	{{ else }}
 		{{ $styles := $styles | minify | fingerprint | resources.PostProcess }}
-		<link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
+		<link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
 	{{ end }}
 	<link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
 	<link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />

--- a/themes/opentermsarchive/layouts/partials/header.html
+++ b/themes/opentermsarchive/layouts/partials/header.html
@@ -31,7 +31,7 @@
               {{ range $.Site.Home.AllTranslations }}
                 {{ if ne $currentLanguage .Language.Lang }}
                   <div class="languageSwitcher_item">
-                    <a href="{{ .Permalink }}">{{ .Language.Lang | upper }}</a>
+                    <a href="{{ .RelPermalink }}">{{ .Language.Lang | upper }}</a>
                   </div>
                 {{ end }}
               {{ end }}


### PR DESCRIPTION
Link tests for new pages were not running because the links in the left-hand menu were absolute URLs of the type `https://docs.opentermsarchive.org/<page>/` and the pages do not yet exist in production.

This changeset corrects this by using relative links, which allows link tests for new pages to run and corrects #76 