### PR TITLE
Revert "Disable taxonomy and section"

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -4,5 +4,4 @@ title: Open Terms Archive documentation
 theme: opentermsarchive
 disableKinds:
   - taxonomy
-  - section
 ignoreErrors: ["error-disable-taxonomy"]


### PR DESCRIPTION
This reverts in part commit 7bccf066438bd744d56eb8e891a49805e0ccaf99 to leave section enabled, see https://github.com/OpenTermsArchive/docs/pull/78#issuecomment-1737214324