### PR TITLE
Preview deploy only on pull request

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,14 +1,6 @@
 [build]
   publish = "public"
 
-# All deploys from the production branch
-[context.production]
-  command = "hugo --minify -b $URL"
-
-[context.production.environment]
-  HUGO_ENV = "production"
-  HUGO_VERSION = "0.119.0"
-
 # All deploys generated from a pull/merge request will inherit these settings.
 [context.deploy-preview]
   command = "hugo --minify -b $DEPLOY_PRIME_URL"


### PR DESCRIPTION
This partially reverts commit 6787eadb4bd698f54aeb9e5b5d1b3bb3ab0e4627 leaving the configuration for pull request preview deployment.