### PR TITLE
Ensure links are always tested on latest content

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,5 @@ jobs:
         with:
           hugo-version: '0.119.0'
           extended: true # Prevent error building site: POSTCSS: failed to transform, see https://gohugo.io/troubleshooting/faq/#i-get-this-feature-is-not-available-in-your-current-hugo-version
-      - name: Build with Hugo
-        run: hugo --minify
       - name: Test broken links
         run: npm run test:links

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "license": "CC BY-SA 4.0",
   "author": "Open Terms Archive",
   "scripts": {
+    "build": "hugo --minify",
     "test": "npm run lint:markdown && npm run lint:css && npm run lint:js && npm run test:links",
+    "pretest:links": "npm run build",
     "test:links": "linkinator ./public --recurse --skip '^https?://(www.linkedin.com|twitter.com|localhost:3000/api/)' --verbosity error",
     "lint:markdown": "markdownlint *.md content/**/*.md",
     "lint:css": "stylelint \"themes/opentermsarchive/assets/css/*.css\"",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Open Terms Archive",
   "scripts": {
     "test": "npm run lint:markdown && npm run lint:css && npm run lint:js && npm run test:links",
-    "test:links": "linkinator ./public --recurse --skip '^(https://www.linkedin.com/.*|https://twitter.com/.*|http://localhost:3000/api/.*)' --verbosity error",
+    "test:links": "linkinator ./public --recurse --skip '^https?://(www.linkedin.com|twitter.com|localhost:3000/api/)' --verbosity error",
     "lint:markdown": "markdownlint *.md content/**/*.md",
     "lint:css": "stylelint \"themes/opentermsarchive/assets/css/*.css\"",
     "lint:js": "eslint themes/opentermsarchive/assets/js/",


### PR DESCRIPTION
This changeset ensures `npm run test:links` always run on the latest version content, including locally. I've been bitten by that error a few times.