### PR TITLE
Fix JSDoc test

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,7 +43,7 @@ jobs:
           hugo config
 
       - name: Build with Hugo
-        run: hugo --minify
+        run: npm run build
 
       - name: Build JSDoc
         run: npm run jsdoc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           hugo-version: '0.119.0'
           extended: true # Prevent error building site: POSTCSS: failed to transform, see https://gohugo.io/troubleshooting/faq/#i-get-this-feature-is-not-available-in-your-current-hugo-version
       - name: Build with Hugo
-        run: hugo --minify
+        run: npm run build
       - name: Build JSDoc
         run: npm run jsdoc
       - name: Test broken links

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,9 @@ jobs:
         with:
           hugo-version: '0.119.0'
           extended: true # Prevent error building site: POSTCSS: failed to transform, see https://gohugo.io/troubleshooting/faq/#i-get-this-feature-is-not-available-in-your-current-hugo-version
+      - name: Build with Hugo
+        run: hugo --minify
+      - name: Build JSDoc
+        run: npm run jsdoc
       - name: Test broken links
         run: npm run test:links

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -308,7 +308,7 @@ The `fetch` module gets the MIME type and content of a document from its URL
 import fetch from '@opentermsarchive/engine/fetch';
 ```
 
-Documentation on how to use `fetch` is provided [as JSDoc](https://docs.opentermsarchive.org/jsdoc/).
+Documentation on how to use `fetch` is provided [as JSDoc](./jsdoc/index.html).
 
 ##### Headless browser management
 
@@ -334,7 +334,7 @@ The `extract` module transforms HTML or PDF content into a Markdown string accor
 import extract from '@opentermsarchive/engine/extract';
 ```
 
-The `extract` function documentation is available [as JSDoc](https://docs.opentermsarchive.org/jsdoc/).
+The `extract` function documentation is available [as JSDoc](./jsdoc/index.html).
 
 #### `SourceDocument`
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
 
 # All deploys generated from a pull/merge request will inherit these settings.
 [context.deploy-preview]
-  command = "hugo --minify -b $DEPLOY_PRIME_URL"
+  command = "hugo --minify -b $DEPLOY_PRIME_URL && npm run jsdoc"
 
 [context.deploy-preview.environment]
   HUGO_ENV = "preview"


### PR DESCRIPTION
That changeset: 
- use relative link to JSDoc
- add missing steps in the test workflow to test the link to the JSDoc
- build the JSDoc in Netlify preview