### PR TITLE
Update Collections governance

### DIFF
--- a/content/collections/create.en.md
+++ b/content/collections/create.en.md
@@ -9,6 +9,12 @@ weight: 3
 
 First of all, define the [metadata]({{< relref "collections/metadata" >}}) of the collection you would like to create.
 
+## Check existing collections
+
+Now that you have a clear idea what you would like to track, double-check that there are no [existing federated collections](https://opentermsarchive.org/#collections) that you could contribute to. If you have a doubt about whether some terms you want to track would fit a collection, reach out to the collection maintainers.
+
+If no existing collection could be a good host for the terms you would like to track, then it is relevant to create your own.
+
 ## Define governance
 
 Setting up and maintaining a collection over time needs fulfilling certain tasks on a regular basis. These tasks are handled through roles. To make sure that all these roles are covered, define the [governance]({{< relref "collections/governance" >}}) of your collection.

--- a/content/collections/create.en.md
+++ b/content/collections/create.en.md
@@ -5,6 +5,8 @@ weight: 3
 
 # Creating a collection
 
+You are considering creating a new collection to track terms with Open Terms Archive? Amazing!
+
 ## Define metadata
 
 First of all, define the [metadata]({{< relref "collections/metadata" >}}) of the collection you would like to create.

--- a/content/collections/create.en.md
+++ b/content/collections/create.en.md
@@ -15,6 +15,12 @@ Now that you have a clear idea what you would like to track, double-check that t
 
 If no existing collection could be a good host for the terms you would like to track, then it is relevant to create your own.
 
+## Inform the community
+
+Starting a new collection is an exciting endeavour, and would strongly benefit from the support of the community who already maintains existing collections. It is strongly recommended to share your intention to create a new collection as early as possible in the process, to get support and identify potential partners.
+
+You can inform the community by posting on the instant messaging system, or [sending an email](mailto:contact@opentermsarchive.org) to the core team.
+
 ## Define governance
 
 Setting up and maintaining a collection over time needs fulfilling certain tasks on a regular basis. These tasks are handled through roles. To make sure that all these roles are covered, define the [governance]({{< relref "collections/governance" >}}) of your collection.

--- a/content/collections/federation.en.md
+++ b/content/collections/federation.en.md
@@ -34,6 +34,16 @@ A **collection** can **join** the Open Terms Archive **federation** if it abides
 9. Publicly accessible API with median response time under 20ms, as evidenced by uptime tracking logs.
 10. Abide by all Open Terms Archive software and data licenses.
 
+## How to join
+
+An official request for joining the federation can be sent by the collection administrator or curator to the core team over email, GitHub or instant messages. That request should contain all necessary content or links that enable assessing the criteria.
+
+The core team will confirm reception of the request and assess the criteria within 4 weeks. The result of the assessment will be provided to the requester through the same means the request was sent, along with a positive decision or a list of improvements that need to be done before a new request can be sent.
+
+Once a positive decision has been issued, the core team will provide the requester with a timeline for joining the federation, on which they will jointly agree.
+
 ## Disclaimer
 
 Please note that establishing the federation is an ongoing effort. While criteria are assessed and refined to strike the right balance between accessibility and quality, the Open Terms Archive core team is responsible for assessing which collections may join the federation, and has the right to update the criteria as requests for joining are made.
+
+The core team has the right to re-assess the federated status of any collection at any given time. In case the federated status of a collection is changed, the collection administrator will be informed immediately, and if possible before the action is made.

--- a/content/collections/federation.en.md
+++ b/content/collections/federation.en.md
@@ -25,14 +25,14 @@ A **collection** can **join** the Open Terms Archive **federation** if it abides
 
 1. Clearly defined [collection metadata]({{< relref "collections/metadata" >}}).
 2. Clearly defined [collection governance]({{< relref "collections/governance" >}}).
-3. The vast majority of **versions** are readable.
-4. **Frequency** of at least one track a day.
-5. Public and open-licensed **declarations**.
-6. Public and open-licensed **snapshots**.
-7. Public and open-licensed **versions**.
-8. Regular, public, and open-licensed **dataset** releases.
-9. Publicly accessible API with median response time under 20ms.
-10. Abide by all software and data licenses.
+3. The vast majority of **versions** are readable, as evidenced by a sample assessment.
+4. **Frequency** of at least one track a day, as evidenced by snapshots.
+5. Public and open-licensed **declarations**, as evidenced by the `LICENSE` file in the declarations repository.
+6. Public and open-licensed **snapshots**, as evidenced by the `LICENSE` file in the snapshots repository.
+7. Public and open-licensed **versions**, as evidenced by the `LICENSE` file in the versions repository.
+8. Regular, public, and open-licensed **dataset** releases, as evidenced by the `LICENSE` file in the datasets.
+9. Publicly accessible API with median response time under 20ms, as evidenced by uptime tracking logs.
+10. Abide by all Open Terms Archive software and data licenses.
 
 ## Disclaimer
 

--- a/content/collections/federation.en.md
+++ b/content/collections/federation.en.md
@@ -17,7 +17,10 @@ A collection that **joins** the **federation** enjoys the following benefits:
 2. Access to the Open Terms Archive GitHub organisation, administered by the Open Terms Archive core team.
 3. Collection logo provided by the Open Terms Archive core team.
 4. Referencing in the official [collections list](https://opentermsarchive.org/collections.json), enabling off-the-shelf discovery in the [Federated API]({{< relref "api/federated" >}}).
-5. Public announcement through all Open Terms Archive communication channels upon joining.
+5. Referencing in the official [datasets list](https://opentermsarchive.org/datasets), providing visibility to analysts.
+6. Dedicated channel on the Open Terms Archive instant messaging system.
+7. API uptime tracking.
+8. Public announcement through all Open Terms Archive communication channels upon joining.
 
 ## Criteria
 

--- a/content/collections/governance.en.md
+++ b/content/collections/governance.en.md
@@ -26,3 +26,7 @@ This role guarantees the quality of the tracked versions by reviewing contributi
 ## Contributor
 
 This role adds declarations and keeps them up to date.
+
+## Sponsor
+
+This optional role supports the existence of the collection by funding other roles, providing agent time, political support, or any other relevant non-operational contribution.


### PR DESCRIPTION
This PR builds upon #111, clarifying some choices that have a strategic impact:

- Define how to join the federation.
- Define how the federation criteria will be assessed.
- Add Sponsor role to collection governance.
- Suggest to inform the community and to check known collections before creating a new collection.

All of the commits are atomic and can be extracted if they prove controversial.