### PR TITLE
Add titles anchor links

### DIFF
--- a/themes/opentermsarchive/assets/css/elements/titles.css
+++ b/themes/opentermsarchive/assets/css/elements/titles.css
@@ -119,3 +119,18 @@ h6,
   color: var(--colorBlack800);
   line-height: 1.25;
 }
+
+.title-anchor {
+  color: var(--colorBlack400);
+  font-size: 0.8em;
+  font-weight: normal;
+  display: none;
+}
+
+h2, h3, h4, h5, h6 {
+  &:hover {
+    a.title-anchor {
+      display: inline;
+    }
+  }
+}

--- a/themes/opentermsarchive/layouts/_default/_markup/render-heading.html
+++ b/themes/opentermsarchive/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,6 @@
+<h{{ .Level }} id="{{ .Anchor }}">
+  {{ .Text | safeHTML }}
+  {{ if ne .Level 1 }}
+    <a class="title-anchor" href="#{{ .Anchor }}">🔗</a>
+  {{ end }}
+</h{{ .Level }}>


### PR DESCRIPTION
Adds anchor links to hover over page titles to make it easier to retrieve these links when referring to them.