### PR TITLE
Document recommended git version

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -113,7 +113,7 @@ Note that older versions of `git` will work but can slow the engine down. It's r
 ```
 git commit-graph write --reachable --changed-paths
 ```
-in the snapshot and version repositories.
+in the snapshot and version repositories. This will significantly increase performance, especially if combined with the `--skipPreRun` and `--skipSnapshots` or `--skipReadBack` options.
 
 ### Getting started
 

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -109,6 +109,12 @@ A [Node.js](https://nodejs.org/en/download/) runtime is required to execute this
 
 ![Supported Node.js version can be found in the package.json file](https://img.shields.io/node/v/@opentermsarchive/engine?color=informational&label=Supported%20Node.js%20version)
 
+Note that older versions of `git` will work but can slow the engine down. It's recommended to use git version 2.29 or higher, and to run:
+```
+git commit-graph write --reachable --changed-paths
+```
+in the snapshot and version repositories.
+
 ### Getting started
 
 This engine is published as a [module on NPM](https://npmjs.com/package/@opentermsarchive/engine). The recommended install is as a dependency in a `package.json` file, next to a folder containing [declaration files](#declarations).


### PR DESCRIPTION
Fixes https://github.com/tosdr/edit.tosdr.org/issues/1162
This simple fix change `git log <path>` execution time in our snapshots repository from 33 seconds to .5 seconds!
See also StackOverflow discussion linked from there.