### PR TITLE
Disable automated link testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,3 @@ jobs:
         run: npm run build
       - name: Build JSDoc
         run: npm run jsdoc
-      - name: Test broken links
-        run: npm run test:links

--- a/README.md
+++ b/README.md
@@ -83,13 +83,7 @@ npm run lint:js -- --fix
 
 ### Check for broken links
 
-Build the site
-
-```sh
-hugo --minify
-```
-
-and run
+To check for broken links, run the following command:
 
 ```sh
 npm run test:links

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "hugo --minify",
     "test": "npm run lint:markdown && npm run lint:css && npm run lint:js && npm run test:links",
     "pretest:links": "npm run build",
-    "test:links": "linkinator ./public --recurse --skip '^https?://(www.linkedin.com|twitter.com|localhost:3000/api/|stackoverflow.com|github.com/organizations/OpenTermsArchive/settings/personal-access-token-requests|joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12|openai.com|github.com|www.nytimes.com)' --verbosity error",
+    "test:links": "linkinator ./public --recurse --verbosity error",
     "lint:markdown": "markdownlint *.md content/**/*.md",
     "lint:css": "stylelint \"themes/opentermsarchive/assets/css/*.css\"",
     "lint:js": "eslint themes/opentermsarchive/assets/js/",


### PR DESCRIPTION
Since the [automatic build](https://github.com/OpenTermsArchive/docs/actions/runs/11500473404) does not pass the link tests and the list of skipped links grows, this changeset removes the automatic links test.