### PR TITLE
Improve reporting doc

### DIFF
--- a/content/collections/explanation/reporting.md
+++ b/content/collections/explanation/reporting.md
@@ -5,28 +5,24 @@ weight: 1
 
 # Reporting
 
-Once services are declared in a collection and this collection starts tracking these terms, it becomes crucial to monitor whether the tracking is functioning properly. It is important to know if there are any terms whose tracking has been interrupted or has failed.
+Over the lifetime of a collection, services will change the location, layout or distribution of their terms. This can impact tracking. In order to ensure continuous data collection, maintainers need to know if the tracking of any terms fails. To address this need, the Open Terms Archive engine automatically reports failures by opening issues in the declarations repository.
 
 ## How the reporting system works
 
-To address this need, the Open Terms Archive engine implements an automated reporting system that creates issues in the declarations repository. This system helps maintainers stay informed about which terms are not being tracked and why.
-
-When tracking is interrupted for a specific term, the system opens an issue that explains why the term is not being tracked and associates labels to categorize the cause of the tracking interruption. The system automatically closes issues when tracking resumes after declarations are fixed and deployed.
+When some terms fail to track, an issue is opened that explains the reason for failure and is labelled based on the cause of the tracking interruption. The system also automatically closes issues when tracking resumes.
 
 ## Understanding labels
 
-The reporting system uses labels to categorize issues and indicate what action is needed.
+The reporting system uses labels to categorize issues and indicate what action, if any, is needed to resume tracking.
 
-### Auto-managed labels
+### Automatically managed labels
 
-All labels that are marked with `- Auto-managed by OTA engine` visible in their description on hover are automatically managed by the engine.
+Labels that are automatically managed by the engine say so in their description, which is visible by hovering the mouse cursor over the label name.
 
-**These labels should not be manually added to issues, modified or removed from them, nor should their descriptions or colors be edited by maintainers.**
-
-The engine will automatically manage these labels as needed.
+**These labels should not be manually added to issues, modified or removed from them, nor should their descriptions or colors be edited by maintainers.** Otherwise, duplication of labels can appear. The engine will automatically manage these labels as needed, ensuring that the cause for interruption is as precisely identified as possible.
 
 ### Issues requiring intervention
 
 The label `⚠ needs intervention` indicates that manual contributor intervention is required to restore tracking. When this label appears on an issue, it means the problem won't be resolved automatically and requires human action to fix the declarations or configuration.
 
-Issues without this label represent tracking interruptions that need investigation to determine the appropriate course of action. These issues may resolve themselves automatically once the underlying problem (such as a temporary network outage or service downtime) is fixed. However, some may not be fixable at all, for example when the tracking engine is detected and blocked as a bot by the target service.
+Issues without this label may resolve themselves automatically once the underlying problem, such as a temporary network outage or service downtime, is fixed. However, some may not be fixable at all, for example when the tracking engine is detected and blocked as a bot by the target service.


### PR DESCRIPTION
- Simplify copywriting.
- Focus on user interactions rather than on system description.
- Remove explicit copy of label descriptions in doc, to minimize need to update the doc for minor wording changes.