### PR TITLE
Update French doc menu

### DIFF
--- a/config/_default/menus.fr.yaml
+++ b/config/_default/menus.fr.yaml
@@ -2,8 +2,8 @@ header:
   - name: Collections
     url: https://opentermsarchive.org/fr/collections/
     weight: 1
-  - name: Mémos
-    url: https://opentermsarchive.org/fr/memos/
+  - name: Publications
+    url: https://opentermsarchive.org/fr/publications/
     weight: 2
   - name: Documentation
     url: /fr


### PR DESCRIPTION
Update the header menu in the French docs to include the French "Publications" page instead of the memos page