### PR TITLE
Update English docs menu

### DIFF
--- a/config/_default/menus.en.yaml
+++ b/config/_default/menus.en.yaml
@@ -2,8 +2,8 @@ header:
   - name: Collections
     url: https://opentermsarchive.org/en/collections/
     weight: 1
-  - name: Memos
-    url: https://opentermsarchive.org/en/memos/
+  - name: Publications
+    url: https://opentermsarchive.org/en/publications/
     weight: 2
   - name: Documentation
     url: /


### PR DESCRIPTION
Update English docs menu to include the "Publications" page instead of the "Memos" page